### PR TITLE
Add basic React application using CDN

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-# vercel-experiment
+# Basic React Application
+
+This repository contains a minimal React application that renders **Hello, React!** using React and ReactDOM loaded from a CDN.
+
+## Usage
+
+Open `index.html` in your browser to view the application.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>React App</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel">
+      function App() {
+        return <h1>Hello, React!</h1>;
+      }
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(<App />);
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "basic-react-app",
+  "version": "1.0.0",
+  "description": "A basic React application using CDN",
+  "scripts": {
+    "test": "echo 'No tests specified' && exit 0"
+  }
+}


### PR DESCRIPTION
## Summary
- bootstrap minimal React app that renders "Hello, React!" in the browser using CDN-hosted React and ReactDOM
- document usage instructions for opening the app
- include basic package.json with placeholder test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68900ffcf22c83288967ce4c8aa4f031