### PR TITLE
Add multi-page experiment layout with side navigation

### DIFF
--- a/color.html
+++ b/color.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Color Experiment</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/colorMain.jsx"></script>
+  </body>
+</html>

--- a/counter.html
+++ b/counter.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Counter Experiment</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/counterMain.jsx"></script>
+  </body>
+</html>

--- a/src/ColorApp.jsx
+++ b/src/ColorApp.jsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import Navbar from './Navbar';
+import SideMenu from './SideMenu';
+import Container from '@mui/material/Container';
+import Typography from '@mui/material/Typography';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+
+function ColorApp() {
+  const colors = ['red', 'blue', 'green', 'yellow', 'purple'];
+  const [color, setColor] = useState(colors[0]);
+
+  const changeColor = () => {
+    const next = colors[Math.floor(Math.random() * colors.length)];
+    setColor(next);
+  };
+
+  return (
+    <>
+      <Navbar />
+      <Box sx={{ display: 'flex' }}>
+        <SideMenu />
+        <Container component="main" sx={{ mt: 4 }}>
+          <Typography variant="h4" component="h1" gutterBottom>
+            Color Experiment
+          </Typography>
+          <Box sx={{ width: 100, height: 100, bgcolor: color, mb: 2 }} />
+          <Button variant="contained" onClick={changeColor}>
+            Change Color
+          </Button>
+        </Container>
+      </Box>
+    </>
+  );
+}
+
+export default ColorApp;

--- a/src/CounterApp.jsx
+++ b/src/CounterApp.jsx
@@ -1,11 +1,14 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Navbar from './Navbar';
 import SideMenu from './SideMenu';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
 import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
 
-function App() {
+function CounterApp() {
+  const [count, setCount] = useState(0);
+
   return (
     <>
       <Navbar />
@@ -13,12 +16,16 @@ function App() {
         <SideMenu />
         <Container component="main" sx={{ mt: 4 }}>
           <Typography variant="h4" component="h1" gutterBottom>
-            Welcome to nicks exploration site
+            Counter Experiment
           </Typography>
+          <Typography variant="h6" gutterBottom>{count}</Typography>
+          <Button variant="contained" onClick={() => setCount(count + 1)}>
+            Increment
+          </Button>
         </Container>
       </Box>
     </>
   );
 }
 
-export default App;
+export default CounterApp;

--- a/src/SideMenu.jsx
+++ b/src/SideMenu.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import Box from '@mui/material/Box';
+import List from '@mui/material/List';
+import ListItem from '@mui/material/ListItem';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemText from '@mui/material/ListItemText';
+
+const menuItems = [
+  { text: 'Home', href: '/' },
+  { text: 'Counter Experiment', href: '/counter.html' },
+  { text: 'Color Experiment', href: '/color.html' },
+];
+
+function SideMenu() {
+  return (
+    <Box component="nav" sx={{ width: 200, flexShrink: 0 }}>
+      <List>
+        {menuItems.map((item) => (
+          <ListItem key={item.text} disablePadding>
+            <ListItemButton component="a" href={item.href}>
+              <ListItemText primary={item.text} />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
+    </Box>
+  );
+}
+
+export default SideMenu;

--- a/src/colorMain.jsx
+++ b/src/colorMain.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import ColorApp from './ColorApp';
+import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
+
+const theme = createTheme();
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <ColorApp />
+    </ThemeProvider>
+  </React.StrictMode>
+);

--- a/src/counterMain.jsx
+++ b/src/counterMain.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import CounterApp from './CounterApp';
+import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
+
+const theme = createTheme();
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <CounterApp />
+    </ThemeProvider>
+  </React.StrictMode>
+);

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,3 +1,13 @@
 import { defineConfig } from 'vite';
 
-export default defineConfig({});
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      input: {
+        main: 'index.html',
+        counter: 'counter.html',
+        color: 'color.html',
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add reusable side menu for navigating between experiment pages
- Include counter and color experiment pages each with their own React entry
- Configure Vite to build multiple HTML entry points

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890c48adb808328ae330f56179d0300