### PR TITLE
feat: add sliding sidebar

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,22 +1,25 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Navbar from './Navbar';
 import SideMenu from './SideMenu';
 import Container from '@mui/material/Container';
 import Typography from '@mui/material/Typography';
-import Box from '@mui/material/Box';
 
 function App() {
+  const [open, setOpen] = useState(false);
+
+  const handleToggle = () => {
+    setOpen(!open);
+  };
+
   return (
     <>
-      <Navbar />
-      <Box sx={{ display: 'flex' }}>
-        <SideMenu />
-        <Container component="main" sx={{ mt: 4 }}>
-          <Typography variant="h4" component="h1" gutterBottom>
-            Welcome to nicks exploration site
-          </Typography>
-        </Container>
-      </Box>
+      <Navbar onMenuClick={handleToggle} />
+      <SideMenu open={open} onClose={handleToggle} />
+      <Container component="main" sx={{ mt: 4 }}>
+        <Typography variant="h4" component="h1" gutterBottom>
+          Welcome to nicks exploration site
+        </Typography>
+      </Container>
     </>
   );
 }

--- a/src/Navbar.jsx
+++ b/src/Navbar.jsx
@@ -4,11 +4,22 @@ import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
 
-function Navbar() {
+function Navbar({ onMenuClick }) {
   return (
     <AppBar position="static">
       <Toolbar>
+        <IconButton
+          edge="start"
+          color="inherit"
+          aria-label="menu"
+          onClick={onMenuClick}
+          sx={{ mr: 2 }}
+        >
+          <MenuIcon />
+        </IconButton>
         <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
           My Site
         </Typography>

--- a/src/SideMenu.jsx
+++ b/src/SideMenu.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import Drawer from '@mui/material/Drawer';
 import Box from '@mui/material/Box';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
@@ -11,19 +12,26 @@ const menuItems = [
   { text: 'Color Experiment', href: '/color.html' },
 ];
 
-function SideMenu() {
+function SideMenu({ open, onClose }) {
   return (
-    <Box component="nav" sx={{ width: 200, flexShrink: 0 }}>
-      <List>
-        {menuItems.map((item) => (
-          <ListItem key={item.text} disablePadding>
-            <ListItemButton component="a" href={item.href}>
-              <ListItemText primary={item.text} />
-            </ListItemButton>
-          </ListItem>
-        ))}
-      </List>
-    </Box>
+    <Drawer anchor="left" open={open} onClose={onClose}>
+      <Box
+        sx={{ width: 250 }}
+        role="presentation"
+        onClick={onClose}
+        onKeyDown={onClose}
+      >
+        <List>
+          {menuItems.map((item) => (
+            <ListItem key={item.text} disablePadding>
+              <ListItemButton component="a" href={item.href}>
+                <ListItemText primary={item.text} />
+              </ListItemButton>
+            </ListItem>
+          ))}
+        </List>
+      </Box>
+    </Drawer>
   );
 }
 


### PR DESCRIPTION
## Summary
- make sidebar a Material UI Drawer that slides out
- allow navbar menu icon to toggle the drawer

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890c70e53608328aab720e2b9954623